### PR TITLE
[#36] 트레픽 분산을 위한 Master/Slave DataSource 동적 라우팅 설정

### DIFF
--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
@@ -31,6 +31,7 @@ class DatasourceConfig {
     fun routingDataSource(
         @Qualifier("masterDataSource") masterDataSource: DataSource,
         @Qualifier("slaveDataSource") slaveDataSource: DataSource
+
     ) = RoutingDataSourceConfig().apply {
 
         setTargetDataSources(HashMap<Any, Any>().apply {

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
@@ -31,16 +31,12 @@ class DatasourceConfig {
     fun routingDataSource(
         @Qualifier("masterDataSource") masterDataSource: DataSource,
         @Qualifier("slaveDataSource") slaveDataSource: DataSource
-
     ) = RoutingDataSourceConfig().apply {
 
-        setTargetDataSources(
-            HashMap<Any, Any>().apply {
-                this[MASTER] = masterDataSource
-                this[SLAVE] = slaveDataSource
-            }
-        )
-
+        setTargetDataSources(HashMap<Any, Any>().apply {
+            this[MASTER] = masterDataSource
+            this[SLAVE] = slaveDataSource
+        })
         setDefaultTargetDataSource(masterDataSource)
     }
 
@@ -59,4 +55,5 @@ class DatasourceConfig {
     fun sqlSessionFactory() = SqlSessionFactoryBean().apply {
         setDataSource(dataSource(routingDataSource(masterDataSource(), slaveDataSource())))
     }.`object`
+
 }

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
@@ -34,10 +34,12 @@ class DatasourceConfig {
 
     ) = RoutingDataSourceConfig().apply {
 
-        setTargetDataSources(HashMap<Any, Any>().apply {
-            this[MASTER] = masterDataSource
-            this[SLAVE] = slaveDataSource
-        })
+        setTargetDataSources(
+            HashMap<Any, Any>().apply {
+                this[MASTER] = masterDataSource
+                this[SLAVE] = slaveDataSource
+            }
+        )
         setDefaultTargetDataSource(masterDataSource)
     }
 
@@ -56,5 +58,4 @@ class DatasourceConfig {
     fun sqlSessionFactory() = SqlSessionFactoryBean().apply {
         setDataSource(dataSource(routingDataSource(masterDataSource(), slaveDataSource())))
     }.`object`
-
 }

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
@@ -1,0 +1,62 @@
+package com.flabedu.blackpostoffice.commom.config
+
+import com.flabedu.blackpostoffice.commom.utils.constants.MASTER
+import com.flabedu.blackpostoffice.commom.utils.constants.SLAVE
+import org.mybatis.spring.SqlSessionFactoryBean
+import org.mybatis.spring.SqlSessionTemplate
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.jdbc.DataSourceBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy
+import org.springframework.transaction.annotation.EnableTransactionManagement
+import javax.sql.DataSource
+
+@Configuration
+@EnableTransactionManagement
+class DatasourceConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.master")
+    fun masterDataSource(): DataSource = DataSourceBuilder.create().build()
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.slave")
+    fun slaveDataSource(): DataSource = DataSourceBuilder.create().build()
+
+    @Bean
+    fun routingDataSource(
+        @Qualifier("masterDataSource") masterDataSource: DataSource,
+        @Qualifier("slaveDataSource") slaveDataSource: DataSource
+
+    ) = RoutingDataSourceConfig().apply {
+
+        setTargetDataSources(
+            HashMap<Any, Any>().apply {
+                this[MASTER] = masterDataSource
+                this[SLAVE] = slaveDataSource
+            }
+        )
+
+        setDefaultTargetDataSource(masterDataSource)
+    }
+
+    @Bean
+    @Primary
+    fun dataSource(@Qualifier("routingDataSource") routingDataSource: DataSource) =
+        LazyConnectionDataSourceProxy(routingDataSource)
+
+    @Bean
+    fun transactionManager(@Qualifier("dataSource") dataSource: DataSource) = DataSourceTransactionManager(dataSource)
+
+    @Bean
+    fun sqlSessionTemplate() = SqlSessionTemplate(sqlSessionFactory())
+
+    @Bean
+    fun sqlSessionFactory() = SqlSessionFactoryBean().apply {
+        setDataSource(dataSource(routingDataSource(masterDataSource(), slaveDataSource())))
+    }.`object`
+}

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/DatasourceConfig.kt
@@ -21,11 +21,11 @@ class DatasourceConfig {
 
     @Bean
     @ConfigurationProperties(prefix = "spring.datasource.master")
-    fun masterDataSource(): DataSource = DataSourceBuilder.create().build()
+    fun masterDataSource() = DataSourceBuilder.create().build()
 
     @Bean
     @ConfigurationProperties(prefix = "spring.datasource.slave")
-    fun slaveDataSource(): DataSource = DataSourceBuilder.create().build()
+    fun slaveDataSource() = DataSourceBuilder.create().build()
 
     @Bean
     fun routingDataSource(

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RoutingDataSourceConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RoutingDataSourceConfig.kt
@@ -9,4 +9,5 @@ class RoutingDataSourceConfig : AbstractRoutingDataSource() {
 
     override fun determineCurrentLookupKey() =
         if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) SLAVE else MASTER
+
 }

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RoutingDataSourceConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RoutingDataSourceConfig.kt
@@ -1,0 +1,12 @@
+package com.flabedu.blackpostoffice.commom.config
+
+import com.flabedu.blackpostoffice.commom.utils.constants.MASTER
+import com.flabedu.blackpostoffice.commom.utils.constants.SLAVE
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource
+import org.springframework.transaction.support.TransactionSynchronizationManager
+
+class RoutingDataSourceConfig : AbstractRoutingDataSource() {
+
+    override fun determineCurrentLookupKey() =
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) SLAVE else MASTER
+}

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RoutingDataSourceConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RoutingDataSourceConfig.kt
@@ -9,5 +9,4 @@ class RoutingDataSourceConfig : AbstractRoutingDataSource() {
 
     override fun determineCurrentLookupKey() =
         if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) SLAVE else MASTER
-
 }

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/utils/constants/DataSourceConstants.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/utils/constants/DataSourceConstants.kt
@@ -1,0 +1,4 @@
+package com.flabedu.blackpostoffice.commom.utils.constants
+
+const val MASTER = "master"
+const val SLAVE = "slave"

--- a/src/main/kotlin/com/flabedu/blackpostoffice/service/PostService.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/service/PostService.kt
@@ -1,0 +1,39 @@
+package com.flabedu.blackpostoffice.service
+
+import com.flabedu.blackpostoffice.controller.dto.post.PostDto
+import com.flabedu.blackpostoffice.controller.dto.post.PostsDto
+import com.flabedu.blackpostoffice.domain.mapper.PostMapper
+import com.flabedu.blackpostoffice.domain.mapper.UserMapper
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PostService(
+    private val postMapper: PostMapper,
+    private val userMapper: UserMapper,
+    private val sessionLoginService: SessionLoginService
+) {
+
+    @Transactional
+    fun createMyPost(createPostDto: PostDto) {
+        postMapper.createMyPost(createPostDto.toCreatePostEntity(sessionLoginService.getCurrentUserEmail()))
+    }
+
+    @Transactional(readOnly = true)
+    fun getPosts(email: String, pageNo: Int, pageSize: Int) = PostsDto(
+        nickName = userMapper.getNickName(email),
+        profileImagePath = userMapper.getProfileImage(email),
+        posts = postMapper.getPosts(email, pageNo, pageSize)
+            .mapTo(arrayListOf()) { PostDto(title = it.title, content = it.content) }
+    )
+
+    @Transactional
+    fun updateMyPost(postId: Long, updatePostDto: PostDto) {
+        postMapper.updateMyPost(updatePostDto.toUpdatePostEntity(postId))
+    }
+
+    @Transactional
+    fun deleteMyPost(postId: Long) {
+        postMapper.deleteMyPost(postId)
+    }
+}

--- a/src/main/kotlin/com/flabedu/blackpostoffice/service/SessionLoginService.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/service/SessionLoginService.kt
@@ -11,6 +11,7 @@ import com.flabedu.blackpostoffice.domain.model.User.Role.USER
 import com.flabedu.blackpostoffice.exception.InvalidRequestException
 import com.flabedu.blackpostoffice.exception.UnauthorizedAccessException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import javax.servlet.http.HttpSession
 
 @Service
@@ -20,6 +21,7 @@ class SessionLoginService(
     private val session: HttpSession,
 ) : LoginService {
 
+    @Transactional(readOnly = true)
     override fun login(userLoginDto: UserLoginDto) {
         invalidLoginCheck(userLoginDto)
         setSessionAttribute(userLoginDto)

--- a/src/main/kotlin/com/flabedu/blackpostoffice/service/UserService.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/service/UserService.kt
@@ -34,14 +34,14 @@ class UserService(
     @Transactional
     fun deleteProfileImage() {
 
-        val getCurrentUserEmail = sessionLoginService.getCurrentUserEmail()
-        val getMyProfileImage = userMapper.getProfileImage(getCurrentUserEmail)
-
-        if (getMyProfileImage != null) {
-            userMapper.updateNullProfileImage(getCurrentUserEmail)
-            amazonS3Service.deleteProfileImage(getMyProfileImage)
+        if (getMyProfileImage(sessionLoginService.getCurrentUserEmail()) != null) {
+            userMapper.updateNullProfileImage(sessionLoginService.getCurrentUserEmail())
+            amazonS3Service.deleteProfileImage(getMyProfileImage(sessionLoginService.getCurrentUserEmail()))
         }
     }
+
+    @Transactional(readOnly = true)
+    fun getMyProfileImage(getCurrentUserEmail: String) = userMapper.getProfileImage(getCurrentUserEmail)
 
     private fun profileImageUpdate(multipartFile: MultipartFile) {
 
@@ -52,6 +52,7 @@ class UserService(
         val uploadProfileImage = amazonS3Service.updateProfileImage(userInfoUpdateDto.profileImagePath)
 
         deleteProfileImage()
+
         userMapper.updateUserInfo(userInfoUpdateDto.toUserInfoUpdate(getCurrentUserEmail, uploadProfileImage))
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses (이 PR이 다루는 문제) -->
Fixes #36?
- 현재 master DB 서버만 존재합니다.
- 사용자가 증가하여 많은 트래픽이 발생할 때,  master DB 서버로 모든 쓰기/읽기 작업이 집중된다면 쉽게 부하가 발생할 위험이 있습니다.
<!--- Detailed description of the change/feature (변경 / 기능에 대한 자세한 설명) -->
### 상세 내용
네이버 클라우드 플랫폼을 이용하여 `master` DB 서버와 Replication된 `slave`  DB 서버를 생성하여
- **master**  DB 서버는 모든 쓰기, 수정, 삭제 작업만 수행하고,
- Replication된 **slave** DB 서버에서는 모든 읽기 작업만을 수행하여 트레픽을 분산시킵니다.

또한 위 과정은 동적으로 라우팅됩니다.

`라우팅이란, 네트워크상에서 주소를 이용, 목적지까지 경로를 체계적으로 결정하는 경로선택 과정입니다.`
