### PR TITLE
최초 빌드시 plain을 생성하지 않도록 plain "enable = false" 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,10 @@ tasks.bootJar {
         .into("static/docs")
 }
 
+tasks.getByName<Jar>("jar") {
+    enabled = false
+}
+
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict")


### PR DESCRIPTION
<!--- The issue this PR addresses (이 PR이 다루는 문제) -->
Fixes #46
배포시 *.jar 읽는 액션에서 메니페스트 정보를 포함하지 않는 plain.jar을 읽는 경우가 있어, 최초 빌드시 plain을 생성하지 않도록 설정
<!--- Detailed description of the change/feature (변경 / 기능에 대한 자세한 설명) -->
### 상세 내용
빌드시 plain.jar 생성되지 않음.
