### PR TITLE
[#55] MySQL 실행 계획 분석을 통해 페이징 성능 개선

### DIFF
--- a/src/main/kotlin/com/flabedu/blackpostoffice/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/mapper/PostMapper.kt
@@ -25,8 +25,8 @@ interface PostMapper {
                  JOIN (SELECT post_id
                        FROM post
                        WHERE email = #{email}
-                       ORDER BY created_at DESC LIMIT #{pageSize}
-                       OFFSET #{pageNo}) as temp on temp.post_id = i.post_id
+                       ORDER BY post_id DESC LIMIT #{pageSize}
+                       OFFSET #{pageNo}) as temp on temp.post_id = i.post_id 
         """
     )
     fun getPosts(email: String, pageNo: Int, pageSize: Int): List<Post>

--- a/src/main/kotlin/com/flabedu/blackpostoffice/service/PostService.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/service/PostService.kt
@@ -19,6 +19,7 @@ class PostService(
         postMapper.createMyPost(sessionLoginService.getCurrentUserEmail(), createPost)
     }
 
+    @Transactional(readOnly = true)
     fun getPosts(email: String, pageNo: Int, pageSize: Int) = Posts(
         nickName = userMapper.getNickName(email),
         profileImagePath = userMapper.getProfileImage(email),

--- a/src/main/kotlin/com/flabedu/blackpostoffice/service/SessionLoginService.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/service/SessionLoginService.kt
@@ -26,11 +26,10 @@ class SessionLoginService(
     }
 
     override fun invalidLoginCheck(userLogin: UserLogin) {
-        val loginCheckEmail = userMapper.getUserByEmail(userLogin.email)
         val loginCheckPassword = sha256Encryption.encryption(userLogin.password)
         val myPassword = userMapper.getPasswordByEmail(userLogin.email)
 
-        if (loginCheckEmail == null || (loginCheckPassword != myPassword)) {
+        if (loginCheckPassword != myPassword) {
             throw InvalidRequestException("아이디가 존재하지 않거나 비밀번호가 일치하지 않습니다.")
         }
     }


### PR DESCRIPTION
<!--- The issue this PR addresses (이 PR이 다루는 문제) -->
Fixes #55

<!--- Detailed description of the change/feature (변경 / 기능에 대한 자세한 설명) -->
### 상세 내용

UI가 무한 스크롤 방식이 아닌 오프셋 페이지 방식(<< 1 | 2 | 3 >>)이기 때문에 커서 기반 페이지네이션 쿼리 방식을 사용하지 않고, 오프셋 기반 페이지네이션 쿼리 방식을 커버링 인덱스를 사용하여 페이징 쿼리의 성능을 개선하려고 아래와 같은 쿼리를 작성하였습니다.

```mysql
        SELECT title, content
        FROM post as i
                 JOIN (SELECT post_id
                       FROM post
                       WHERE email = #{email}
                       ORDER BY created_at DESC LIMIT #{pageSize} // 문제가 되었던 created_at
                       OFFSET #{pageNo}) as temp on temp.post_id = i.post_id 
```

하지만 실행 계획 분석시 아래와 같은 두 가지 문제점을 발견하였습니다.
- **type 필드가 ALL**이기 때문에, 테이블 풀 스캔이 일어난다는 것을 확인.
- **Extra필드에 Using Index**가 포함되지 않았기 때문에 커버링 인덱스 방식이 적용이 되지 않았다는 걸 확인.

이유는 `ORDER BY created_at` 때문이였습니다.

커버링 인덱스가 사용되려면, select절을 비롯해 order by, where 등 쿼리 내 모든 항목이 인덱스 컬럼으로만 이루어지게 하여 인덱스 내부에서 쿼리가 완성되어야 합니다. 

하지만 현재 created_at를 제외한 항목들은 인덱스 컬럼으로 이루어져 있었지만,
- `created_at` 컬럼은 인덱스 컬럼으로 되어 있지 않았습니다. 
- 또한 조건문에 `created_at`가 아닌 인덱스 컬럼으로 되어 있는 `post_id`를 사용해야 커버링 인덱스를 사용할 수 있다고 생각하였습니다.

따라서 ` ORDER BY created_at DESC` -> ` ORDER BY post_id DESC`로 리팩토링하였고 EXPLAIN 결과,
-  Extra 필드에 `Using index` 표기되어 커버링 인덱스가 사용이 된 것을 확인하였고, Type 필드에 `ref`가 표기되어 인덱스 접근 방식이 사용된 것을 확인하였습니다.
- 더 정확한 확인을 위해 테이블에 천만 건 이상의 더미 데이터를 넣은 후,  pageNo = 10000000(1000만), pageSize = 10의 조건으로 쿼리의 속도를 측정해 보았는데, **쿼리튜닝 전 4초 -> 쿼리튜닝 후 0.5초**의 성능이 개선된 것을 확인하였습니다.

[실행 계획 분석을 통해 페이징 성능 개선 과정을 작성한 글 입니다.](https://junghyungil.tistory.com/180)


