### PR TITLE
Redis CacheManager를 설정하여 전체 사용자 피드 조회 캐싱 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ![기술 스택](https://user-images.githubusercontent.com/43127088/125194910-4c673e00-e28e-11eb-80c8-1a3bda1be8df.PNG)
 
 ### 현재까지의 서버 구조도
-![서버 구조도](https://user-images.githubusercontent.com/43127088/128609328-f679ba29-50bd-47af-a544-0da869261de7.png)
+![서버 구조도](![Untitled Diagram drawio (2)](https://user-images.githubusercontent.com/43127088/133897837-7f89fd9b-1761-4fcf-8ed7-a70aca1214a3.png)
 
 ### 프로젝트 주요 관심사
 - 여러 기술들의 트레이드 오프를 고려한 후, 어떤 기술을 도입하는 것이 가장 서비스에 가장 적합할까?

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ![기술 스택](https://user-images.githubusercontent.com/43127088/125194910-4c673e00-e28e-11eb-80c8-1a3bda1be8df.PNG)
 
 ### 현재까지의 서버 구조도
-![Untitled Diagram drawio (3)](https://user-images.githubusercontent.com/43127088/133906885-62d889e1-7cf3-45eb-b5b1-3b7292747ed7.png)
+![Untitled Diagram drawio (4)](https://user-images.githubusercontent.com/43127088/133907589-ab8c0f12-9e79-423a-9248-a4dba9b92e4b.png)
 
 ### 현재까지의 디렉토리 구조
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 ### 현재까지의 사용기술
 ![기술 스택](https://user-images.githubusercontent.com/43127088/125194910-4c673e00-e28e-11eb-80c8-1a3bda1be8df.PNG)
 
-### 현재까지의 서버 구조도
+### 서버 구조도
 ![Untitled Diagram drawio (4)](https://user-images.githubusercontent.com/43127088/133907589-ab8c0f12-9e79-423a-9248-a4dba9b92e4b.png)
 
-### 현재까지의 디렉토리 구조
+### 디렉토리 구조
 ```bash
 └─ src
    ├─ docs                                       Rest Docs API 자동화 관련

--- a/README.md
+++ b/README.md
@@ -18,7 +18,39 @@
 ![기술 스택](https://user-images.githubusercontent.com/43127088/125194910-4c673e00-e28e-11eb-80c8-1a3bda1be8df.PNG)
 
 ### 현재까지의 서버 구조도
-![서버 구조도](![Untitled Diagram drawio (2)](https://user-images.githubusercontent.com/43127088/133897837-7f89fd9b-1761-4fcf-8ed7-a70aca1214a3.png)
+![Untitled Diagram drawio (2)](https://user-images.githubusercontent.com/43127088/133897837-7f89fd9b-1761-4fcf-8ed7-a70aca1214a3.png)
+
+### 현재까지의 디렉토리 구조
+```bash
+└─ src
+   ├─ docs                                       Rest Docs API 자동화 관련
+      ├─ api-guide.adoc
+      ├─ api-html.adoc
+      
+   ├─ main
+      ├─ kotlin
+         ├─ com.flabedu.blackpostoffice
+            ├─ commom                             공통으로 사용하는 파일들
+               ├─ annotation                        - 사용자 권한 체크등 관련된 어노테이션            
+               ├─ config                            - Redis, MySQL Replication, S3등 설정 파일 관련 
+               ├─ encryption                        - 비밀번호 암호화등 관련
+               ├─ enumeration                       - 사용자 권한 부여등 Enum Class
+               ├─ interceptor                       - 스프링 인터셉터를 통해 중복 코드를 제거하기 위한 것과 관련
+               ├─ property                          - yml파일을 객체에 매핑하여 property로 사용
+               ├─ utils.constants                   - 공통 상수 관련
+            ├─ controller                         Model과 View의 연결하는 제어 로직을 담당
+            ├─ exception                          예외처리 관련
+               ├─ dto                               - 예외처리 관련 데이터 교환을 위해 사용
+               ├─ handler                           - 전역적으로 예외를 다루는 핸들러                          
+             ├─ mapper                            Mybatis 매핑XML에 기재된 SQL을 호출하기 위한 인터페이스
+             ├─ model                             비즈니스 로직과 사용되는 데이터를 다루는 영역
+             ├─ service                           비즈니스 로직을 수행
+             
+   ├─ test                                        테스트 코드 관련
+      ├─ kotlin
+         ├─ com.flabedu.blackpostoffice
+            ├─ ...                     
+```
 
 ### 프로젝트 주요 관심사
 - 여러 기술들의 트레이드 오프를 고려한 후, 어떤 기술을 도입하는 것이 가장 서비스에 가장 적합할까?

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ![기술 스택](https://user-images.githubusercontent.com/43127088/125194910-4c673e00-e28e-11eb-80c8-1a3bda1be8df.PNG)
 
 ### 현재까지의 서버 구조도
-![Untitled Diagram drawio (2)](https://user-images.githubusercontent.com/43127088/133897837-7f89fd9b-1761-4fcf-8ed7-a70aca1214a3.png)
+![Untitled Diagram drawio (3)](https://user-images.githubusercontent.com/43127088/133906885-62d889e1-7cf3-45eb-b5b1-3b7292747ed7.png)
 
 ### 현재까지의 디렉토리 구조
 ```bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.3")
     implementation("com.amazonaws:aws-java-sdk-s3:1.12.17")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+")
 
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     asciidoctor("org.springframework.restdocs:spring-restdocs-asciidoctor")

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -12,41 +12,41 @@ Junghyungile<junghyungile@gmail.com>
 [[overview_http_verbs]]
 == HTTP Methods
 
-클라이언트와 서버 사이에 이루어지는 요청(Request)과 응답(Response) 데이터를 전송하는 방식.
+클라이언트와 서버 사이에 이루어지는 요청(Request)과 응답(Response) 데이터를 전송하는 방식입니다.
 
 |===
 | Method | Content
 
 | `GET`
-| 요청받은 URI의 정보를 검색하여 응답한다.
+| 요청받은 URI의 정보를 검색하여 응답합니다.
 
 | `POST`
-| 요청된 자원을 생성(CREATE) 한다.
+| 요청된 자원을 생성(CREATE) 합니다.
 
 | `PUT`
-| 요청된 자원을 수정(UPDATE)한다. 리소스의 모든 것을 업데이트 한다.
+| 요청된 자원을 수정(UPDATE)한다. 리소스의 모든 것을 업데이트 합니다..
 
 | `PATCH`
-| PUT과 유사하게 요청된 자원을 수정(UPATE) 할 때 사용한다. 리소스의 일부를 업데이트 한다.
+| PUT과 유사하게 요청된 자원을 수정(UPATE) 할 때 사용한다. 리소스의 일부를 업데이트 합니다.
 
 | `DELETE`
-| 요청된 자원을 삭제할 것을 요청한다.
+| 요청된 자원을 삭제할 것을 요청합니다.
 |===
 
 [[overview_http_status_codes]]
 == HTTP status codes
 
-모든 HTTP 응답 코드는 5개의 클래스(분류)로 구분된다. 상태 코드의 첫 번째 숫자는 응답의 클래스를 정의한다. 첫자리에 대한 5가지 값들은 다음과 같다:
+모든 HTTP 응답 코드는 5개의 클래스(분류)로 구분된다. 상태 코드의 첫 번째 숫자는 응답의 클래스를 정의한다. 첫자리에 대한 5가지 값들은 다음과 같습니다:
 
-1xx (정보): 요청을 받았으며 프로세스를 계속한다
+1xx (정보): 요청을 받았으며 프로세스를 계속합니다.
 
-2xx (성공): 요청을 성공적으로 받았으며 인식했고 수용하였다
+2xx (성공): 요청을 성공적으로 받았으며 인식했고 수용합니다.
 
-3xx (리다이렉션): 요청 완료를 위해 추가 작업 조치가 필요하다
+3xx (리다이렉션): 요청 완료를 위해 추가 작업 조치가 필요합니다.
 
-4xx (클라이언트 오류): 요청의 문법이 잘못되었거나 요청을 처리할 수 없다
+4xx (클라이언트 오류): 요청의 문법이 잘못되었거나 요청을 처리할 수 없습니다.
 
-5xx (서버 오류): 서버가 명백히 유효한 요청에 대해 충족을 실패했다
+5xx (서버 오류): 서버가 명백히 유효한 요청에 대해 충족을 실패습니다.
 
 |===
 | Status code | Usage
@@ -198,7 +198,7 @@ include::{snippets}/posts/update/successful/http-request.adoc[]
 **응답 예시**
 include::{snippets}/posts/update/successful/http-response.adoc[]
 
-=== 1-3 게시물 조회
+=== 1-3 특정 회원 게시물 조회
 
 **curl**
 include::{snippets}/posts/get/successful/curl-request.adoc[]
@@ -215,7 +215,24 @@ include::{snippets}/posts/get/successful/response-fields.adoc[]
 **응답 예시**
 include::{snippets}/posts/get/successful/http-response.adoc[]
 
-=== 1-4 게시물 삭제
+=== 1-4 전체 회원 게시물 조회
+
+**curl**
+include::{snippets}/posts/get/users/successful/curl-request.adoc[]
+
+**요청 파라미터**
+include::{snippets}/posts/get/users/successful/request-parameters.adoc[]
+
+**요청 예시**
+include::{snippets}/posts/get/users/successful/http-request.adoc[]
+
+**응답 필드**
+include::{snippets}/posts/get/users/successful/response-fields.adoc[]
+
+**응답 예시**
+include::{snippets}/posts/get/users/successful/http-response.adoc[]
+
+=== 1-5 게시물 삭제
 
 **curl**
 include::{snippets}/posts/delete/successful/curl-request.adoc[]

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RedisCacheConfig.kt
@@ -1,0 +1,45 @@
+package com.flabedu.blackpostoffice.commom.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
+import com.flabedu.blackpostoffice.commom.property.RedisCacheProperties
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisCacheConfig(val cacheProperties: RedisCacheProperties) {
+
+    @Bean("redisCacheConnectionFactory")
+    fun redisCacheConnectionFactory() = LettuceConnectionFactory(cacheProperties.host, cacheProperties.port)
+
+    @Bean
+    fun redisCacheManager() =
+        RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisCacheConnectionFactory())
+            .cacheDefaults(redisCacheDefaultConfiguration()).build()
+
+    private fun objectMapper() = ObjectMapper().apply {
+
+        val ptv = BasicPolymorphicTypeValidator.builder().allowIfSubType(Any::class.java).build()
+
+        registerModule(ParameterNamesModule())
+        activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL)
+    }
+
+    private fun redisCacheDefaultConfiguration() = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+        .serializeValuesWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(
+                GenericJackson2JsonRedisSerializer(objectMapper())
+            )
+        ).entryTtl(Duration.ofSeconds(cacheProperties.ttl))
+}

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RedisCacheConfig.kt
@@ -27,7 +27,8 @@ class RedisCacheConfig(val cacheProperties: RedisCacheProperties) {
         RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisCacheConnectionFactory())
             .cacheDefaults(redisCacheDefaultConfiguration()).build()
 
-    private fun objectMapper() = ObjectMapper().apply {
+    @Bean
+    fun objectMapper() = ObjectMapper().apply {
 
         val ptv = BasicPolymorphicTypeValidator.builder().allowIfSubType(Any::class.java).build()
 
@@ -35,7 +36,8 @@ class RedisCacheConfig(val cacheProperties: RedisCacheProperties) {
         activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL)
     }
 
-    private fun redisCacheDefaultConfiguration() = RedisCacheConfiguration.defaultCacheConfig()
+    @Bean
+    fun redisCacheDefaultConfiguration() = RedisCacheConfiguration.defaultCacheConfig()
         .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
         .serializeValuesWith(
             RedisSerializationContext.SerializationPair.fromSerializer(

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RedisCacheConfig.kt
@@ -36,8 +36,7 @@ class RedisCacheConfig(val cacheProperties: RedisCacheProperties) {
         activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL)
     }
 
-    @Bean
-    fun redisCacheDefaultConfiguration() = RedisCacheConfiguration.defaultCacheConfig()
+    private fun redisCacheDefaultConfiguration() = RedisCacheConfiguration.defaultCacheConfig()
         .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
         .serializeValuesWith(
             RedisSerializationContext.SerializationPair.fromSerializer(

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RedisSessionConfig.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/config/RedisSessionConfig.kt
@@ -3,6 +3,7 @@ package com.flabedu.blackpostoffice.commom.config
 import com.flabedu.blackpostoffice.commom.property.RedisProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
@@ -11,17 +12,14 @@ import org.springframework.session.data.redis.config.annotation.web.http.EnableR
 
 @Configuration
 @EnableRedisHttpSession
-class RedisConfig(
-
-    val redisProperties: RedisProperties
-
-) {
+class RedisSessionConfig(val redisProperties: RedisProperties) {
 
     @Bean
+    @Primary
     fun redisConnectionFactory() = LettuceConnectionFactory(redisProperties.host, redisProperties.port)
 
-    @Bean
-    fun redisTemplate(): RedisTemplate<String, Any> {
+    @Bean("sessionRedisTemplate")
+    fun sessionRedisTemplate(): RedisTemplate<String, Any> {
 
         val redisTemplate = RedisTemplate<String, Any>()
 

--- a/src/main/kotlin/com/flabedu/blackpostoffice/commom/property/RedisCacheProperties.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/commom/property/RedisCacheProperties.kt
@@ -1,0 +1,13 @@
+package com.flabedu.blackpostoffice.commom.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "spring.redis.cache")
+class RedisCacheProperties(
+    val host: String,
+    val port: Int,
+    val key: String,
+    val ttl: Long
+)

--- a/src/main/kotlin/com/flabedu/blackpostoffice/controller/PostController.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/controller/PostController.kt
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/posts")
 class PostController(
-    private val postService: PostService
+    private val postService: PostService,
 ) {
 
     @PostMapping
@@ -30,17 +30,26 @@ class PostController(
     }
 
     @GetMapping
+    @ResponseStatus(HttpStatus.OK)
     @AuthorizedAccessCheck(authority = USER)
-    fun getPosts(@RequestParam email: String, @RequestParam pageNo: Int, @RequestParam pageSize: Int) =
-        postService.getPosts(email, pageNo, pageSize)
+    fun getUserPosts(@RequestParam email: String, @RequestParam pageNo: Int, @RequestParam pageSize: Int) =
+        postService.getUserPosts(email, pageNo, pageSize)
+
+    @GetMapping("/users")
+    @ResponseStatus(HttpStatus.OK)
+    @AuthorizedAccessCheck(authority = USER)
+    fun getUsersPosts(@RequestParam pageNo: Int, @RequestParam pageSize: Int) =
+        postService.getUsersPosts(pageNo, pageSize)
 
     @PatchMapping("/{postId}")
+    @ResponseStatus(HttpStatus.CREATED)
     @AuthorizedAccessCheck(authority = USER)
     fun updateMyPost(@PathVariable postId: Long, @RequestBody post: Post) {
         postService.updateMyPost(postId, post)
     }
 
     @DeleteMapping("/{postId}")
+    @ResponseStatus(HttpStatus.OK)
     @AuthorizedAccessCheck(authority = USER)
     fun deleteMyPost(@PathVariable postId: Long) {
         postService.deleteMyPost(postId)

--- a/src/main/kotlin/com/flabedu/blackpostoffice/controller/UserController.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/controller/UserController.kt
@@ -28,14 +28,16 @@ class UserController(
         userService.saveUser(userSignUp)
     }
 
-    @AuthorizedAccessCheck(authority = USER)
     @PatchMapping("/my-info")
+    @ResponseStatus(HttpStatus.CREATED)
+    @AuthorizedAccessCheck(authority = USER)
     fun userInfoUpdate(@RequestPart("profileImage") multipartFile: MultipartFile) {
         userService.userInfoUpdate(multipartFile)
     }
 
-    @AuthorizedAccessCheck(authority = USER)
     @PutMapping("/profile-image")
+    @ResponseStatus(HttpStatus.OK)
+    @AuthorizedAccessCheck(authority = USER)
     fun deleteProfileImage() {
         userService.deleteProfileImage()
     }

--- a/src/main/kotlin/com/flabedu/blackpostoffice/controller/UserLoginController.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/controller/UserLoginController.kt
@@ -4,9 +4,11 @@ import com.flabedu.blackpostoffice.commom.annotation.AuthorizedAccessCheck
 import com.flabedu.blackpostoffice.commom.enumeration.Role.USER
 import com.flabedu.blackpostoffice.model.user.UserLogin
 import com.flabedu.blackpostoffice.service.SessionLoginService
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
 
@@ -17,12 +19,14 @@ class UserLoginController(
 ) {
 
     @PostMapping("/login")
+    @ResponseStatus(HttpStatus.OK)
     fun login(@Valid @RequestBody userLogin: UserLogin) {
         sessionLoginService.login(userLogin)
     }
 
-    @AuthorizedAccessCheck(authority = USER)
     @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.OK)
+    @AuthorizedAccessCheck(authority = USER)
     fun logout() {
         sessionLoginService.logout()
     }

--- a/src/main/kotlin/com/flabedu/blackpostoffice/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/mapper/PostMapper.kt
@@ -33,7 +33,7 @@ interface PostMapper {
 
     @Select(
         """
-        SELECT email, title, content
+        SELECT title, content
         FROM post as i
                  JOIN (SELECT post_id
                        FROM post

--- a/src/main/kotlin/com/flabedu/blackpostoffice/mapper/PostMapper.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/mapper/PostMapper.kt
@@ -29,7 +29,19 @@ interface PostMapper {
                        OFFSET #{pageNo}) as temp on temp.post_id = i.post_id 
         """
     )
-    fun getPosts(email: String, pageNo: Int, pageSize: Int): List<Post>
+    fun getUserPosts(email: String, pageNo: Int, pageSize: Int): List<Post>
+
+    @Select(
+        """
+        SELECT email, title, content
+        FROM post as i
+                 JOIN (SELECT post_id
+                       FROM post
+                       ORDER BY post_id DESC LIMIT #{pageSize}
+                       OFFSET #{pageNo}) as temp on temp.post_id = i.post_id 
+        """
+    )
+    fun getUsersPosts(pageNo: Int, pageSize: Int): List<Post>
 
     @Update(
         """

--- a/src/main/kotlin/com/flabedu/blackpostoffice/service/PostService.kt
+++ b/src/main/kotlin/com/flabedu/blackpostoffice/service/PostService.kt
@@ -4,6 +4,8 @@ import com.flabedu.blackpostoffice.mapper.PostMapper
 import com.flabedu.blackpostoffice.mapper.UserMapper
 import com.flabedu.blackpostoffice.model.post.Post
 import com.flabedu.blackpostoffice.model.post.Posts
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -20,19 +22,25 @@ class PostService(
     }
 
     @Transactional(readOnly = true)
-    fun getPosts(email: String, pageNo: Int, pageSize: Int) = Posts(
+    fun getUserPosts(email: String, pageNo: Int, pageSize: Int) = Posts(
         nickName = userMapper.getNickName(email),
         profileImagePath = userMapper.getProfileImage(email),
-        posts = postMapper.getPosts(email, pageNo, pageSize)
-            .mapTo(arrayListOf()) { Post(title = it.title, content = it.content) }
+        posts = postMapper.getUserPosts(email, pageNo, pageSize).map { Post(title = it.title, content = it.title) }
     )
 
+    @Transactional(readOnly = true)
+    @Cacheable(value = ["Posts"])
+    fun getUsersPosts(pageNo: Int, pageSize: Int) =
+        postMapper.getUsersPosts(pageNo, pageSize).map { Post(title = it.title, content = it.title) }
+
     @Transactional
+    @CacheEvict(value = ["Posts"], allEntries = true)
     fun updateMyPost(postId: Long, updatePost: Post) {
         postMapper.updateMyPost(postId, updatePost)
     }
 
     @Transactional
+    @CacheEvict(value = ["Posts"], allEntries = true)
     fun deleteMyPost(postId: Long) {
         postMapper.deleteMyPost(postId)
     }

--- a/src/test/kotlin/com/flabedu/blackpostoffice/controller/PostControllerTest.kt
+++ b/src/test/kotlin/com/flabedu/blackpostoffice/controller/PostControllerTest.kt
@@ -2,6 +2,7 @@ package com.flabedu.blackpostoffice.controller
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.flabedu.blackpostoffice.mapper.UserMapper
 import com.flabedu.blackpostoffice.model.post.Post
 import com.flabedu.blackpostoffice.model.post.Posts
 import com.flabedu.blackpostoffice.service.PostService
@@ -18,13 +19,18 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.headers.HeaderDocumentation
+import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
 import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
-import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
+import org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
@@ -34,9 +40,8 @@ import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.restdocs.request.RequestDocumentation.requestParameters
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
@@ -56,6 +61,9 @@ internal class PostControllerTest @Autowired constructor(
 
     @MockBean
     lateinit var sessionLoginService: SessionLoginService
+
+    @MockBean
+    lateinit var userMapper: UserMapper
 
     private lateinit var post: Post
     private var postList: MutableList<Post> = arrayListOf()
@@ -91,19 +99,18 @@ internal class PostControllerTest @Autowired constructor(
         doNothing().`when`(postService)?.createMyPost(post)
 
         mockMvc.perform(
-            MockMvcRequestBuilders.post("/posts")
+            post("/posts")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJsonString(post))
         )
 
-            .andExpect(MockMvcResultMatchers.status().isCreated)
+            .andExpect(status().isCreated)
             .andDo(
                 document(
                     "posts/create/successful", getDocumentRequest(), getDocumentResponse(),
 
                     requestHeaders(
-                        HeaderDocumentation.headerWithName(HttpHeaders.CONTENT_TYPE)
-                            .description("Content-type")
+                        headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-type")
                     ),
 
                     requestFields(
@@ -125,17 +132,14 @@ internal class PostControllerTest @Autowired constructor(
                 .content(toJsonString(post))
         )
 
-            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(status().isCreated)
             .andDo(
                 document(
                     "posts/update/successful", getDocumentRequest(), getDocumentResponse(),
 
                     pathParameters(parameterWithName("id").description("수정할 게시글의 번호")),
 
-                    requestHeaders(
-                        HeaderDocumentation.headerWithName(HttpHeaders.CONTENT_TYPE)
-                            .description("Content-type")
-                    ),
+                    requestHeaders(headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-type")),
 
                     requestFields(
                         fieldWithPath("title").type(JsonFieldType.STRING).description("게시물 제목 수정"),
@@ -146,23 +150,22 @@ internal class PostControllerTest @Autowired constructor(
     }
 
     @Test
-    fun `게시물 조회에 성공할 경우 Http Status Code 200(Ok) 반환`() {
+    fun `특정 사용자 게시물 조회에 성공할 경우 Http Status Code 200(Ok) 반환`() {
 
-        given(postService.getPosts("test@gmail.com", 0, 10)).willReturn(posts)
+        given(postService.getUserPosts("test@gmail.com", 0, 10)).willReturn(posts)
 
         mockMvc.perform(
-            MockMvcRequestBuilders.get("/posts?email=test@gmail.com&pageNo=0&pageSize=10")
+            get("/posts?email=test@gmail.com&pageNo=0&pageSize=10")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJsonString(posts))
         )
 
-            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(status().isOk)
             .andDo(
                 document(
                     "posts/get/successful", getDocumentRequest(), getDocumentResponse(),
 
                     requestHeaders(
-                        HeaderDocumentation.headerWithName(HttpHeaders.CONTENT_TYPE)
+                        headerWithName(HttpHeaders.CONTENT_TYPE)
                             .description("Content-type")
                     ),
 
@@ -174,9 +177,43 @@ internal class PostControllerTest @Autowired constructor(
 
                     responseFields(
                         fieldWithPath("nickName").type(JsonFieldType.STRING).description("조회한 게시글을 작성한 사용자의 닉네임"),
-                        fieldWithPath("profileImagePath").type(JsonFieldType.NULL).description("조회한 게시글을 작성한 사용자의 프로필 사진"),
+                        fieldWithPath("profileImagePath").type(JsonFieldType.NULL)
+                            .description("조회한 게시글을 작성한 사용자의 프로필 사진"),
                         fieldWithPath("posts.[].title").type(JsonFieldType.STRING).description("조회한 게시물의 제목"),
                         fieldWithPath("posts.[].content").type(JsonFieldType.STRING).description("조회한 게시물의 내용")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `전체 사용자 게시물 조회에 성공할 경우 Http Status Code 200(Ok) 반환`() {
+
+        given(postService.getUsersPosts(0, 10)).willReturn(postList)
+
+        mockMvc.perform(
+            get("/posts/users?pageNo=0&pageSize=10")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+
+            .andExpect(status().isOk)
+            .andDo(
+                document(
+                    "posts/get/users/successful", getDocumentRequest(), getDocumentResponse(),
+
+                    requestHeaders(
+                        headerWithName(HttpHeaders.CONTENT_TYPE)
+                            .description("Content-type")
+                    ),
+
+                    requestParameters(
+                        parameterWithName("pageNo").description("조회할 게시글의 페이지").optional(),
+                        parameterWithName("pageSize").description("조회할 게시글의 페이지당 게시글 수").optional()
+                    ),
+
+                    responseFields(
+                        fieldWithPath("[].title").type(JsonFieldType.STRING).description("조회한 게시물의 제목"),
+                        fieldWithPath("[].content").type(JsonFieldType.STRING).description("조회한 게시물의 내용")
                     )
                 )
             )
@@ -191,7 +228,7 @@ internal class PostControllerTest @Autowired constructor(
             delete("/posts/{id}", 1)
                 .contentType(MediaType.APPLICATION_JSON)
         )
-            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(status().isOk)
             .andDo(
                 document(
                     "posts/delete/successful",
@@ -204,15 +241,12 @@ internal class PostControllerTest @Autowired constructor(
     }
 
     fun getDocumentRequest() =
-        Preprocessors.preprocessRequest(
-            Preprocessors.modifyUris().scheme("http").host("localhost").port(8080),
-            Preprocessors.prettyPrint()
-        )
+        preprocessRequest(modifyUris().scheme("http").host("localhost").port(8080), prettyPrint())
 
-    fun getDocumentResponse() = Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+    fun getDocumentResponse() = preprocessResponse(prettyPrint())
 
     @Throws(JsonProcessingException::class)
-    private fun toJsonString(userSignUpDto: Any): String {
-        return objectMapper.writeValueAsString(userSignUpDto)
+    private fun toJsonString(dto: Any): String {
+        return objectMapper.writeValueAsString(dto)
     }
 }

--- a/src/test/kotlin/com/flabedu/blackpostoffice/controller/PostControllerTest.kt
+++ b/src/test/kotlin/com/flabedu/blackpostoffice/controller/PostControllerTest.kt
@@ -62,9 +62,6 @@ internal class PostControllerTest @Autowired constructor(
     @MockBean
     lateinit var sessionLoginService: SessionLoginService
 
-    @MockBean
-    lateinit var userMapper: UserMapper
-
     private lateinit var post: Post
     private var postList: MutableList<Post> = arrayListOf()
     private lateinit var posts: Posts

--- a/src/test/kotlin/com/flabedu/blackpostoffice/controller/PostControllerTest.kt
+++ b/src/test/kotlin/com/flabedu/blackpostoffice/controller/PostControllerTest.kt
@@ -2,7 +2,6 @@ package com.flabedu.blackpostoffice.controller
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.flabedu.blackpostoffice.mapper.UserMapper
 import com.flabedu.blackpostoffice.model.post.Post
 import com.flabedu.blackpostoffice.model.post.Posts
 import com.flabedu.blackpostoffice.service.PostService

--- a/src/test/kotlin/com/flabedu/blackpostoffice/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/flabedu/blackpostoffice/controller/UserControllerTest.kt
@@ -25,6 +25,8 @@ import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
 import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put
 import org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -101,7 +103,7 @@ internal class UserControllerTest @Autowired constructor(
         doNothing().`when`(userService)?.saveUser(userSignUp)
 
         mockMvc.perform(
-            MockMvcRequestBuilders.post("/users")
+            post("/users")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJsonString(userSignUp))
         )
@@ -130,7 +132,7 @@ internal class UserControllerTest @Autowired constructor(
         doThrow(DuplicateRequestException("이미 존재하는 이메일 입니다.")).`when`(userService).saveUser(userSignUp)
 
         mockMvc.perform(
-            MockMvcRequestBuilders.post("/users")
+            post("/users")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJsonString(userSignUp))
         )
@@ -157,6 +159,7 @@ internal class UserControllerTest @Autowired constructor(
     fun `회원정보 수정 성공`() {
 
         val builder: MockMultipartHttpServletRequestBuilder = MockMvcRequestBuilders.multipart("/users/my-info")
+
         builder.with { request ->
             request.method = "PATCH"
             request
@@ -170,7 +173,7 @@ internal class UserControllerTest @Autowired constructor(
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andDo { println() }
-            .andExpect(status().isOk)
+            .andExpect(status().isCreated)
             .andDo(
                 document(
                     "users/my-info/update/successful", getDocumentRequest(), getDocumentResponse(),
@@ -188,7 +191,7 @@ internal class UserControllerTest @Autowired constructor(
         doNothing().`when`(userService)?.deleteProfileImage()
 
         mockMvc.perform(
-            MockMvcRequestBuilders.put("/users/profile-image")
+            put("/users/profile-image")
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isOk)
@@ -212,7 +215,7 @@ internal class UserControllerTest @Autowired constructor(
         MockMultipartFile("profileImage", "profileImage", "image/png", "profileImage".toByteArray())
 
     @Throws(JsonProcessingException::class)
-    private fun toJsonString(userSignUp: UserSignUp): String {
-        return objectMapper.writeValueAsString(userSignUp)
+    private fun toJsonString(dto: Any): String {
+        return objectMapper.writeValueAsString(dto)
     }
 }

--- a/src/test/kotlin/com/flabedu/blackpostoffice/controller/UserLoginControllerTest.kt
+++ b/src/test/kotlin/com/flabedu/blackpostoffice/controller/UserLoginControllerTest.kt
@@ -21,13 +21,16 @@ import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
-import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
+import org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -78,7 +81,7 @@ internal class UserLoginControllerTest @Autowired constructor(
         doNothing().`when`(sessionLoginService).login(userLogin)
 
         mockMvc.perform(
-            MockMvcRequestBuilders.post("/users/login")
+            post("/users/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJsonString(userLogin))
                 .session(session)
@@ -104,7 +107,7 @@ internal class UserLoginControllerTest @Autowired constructor(
             .login(userLogin)
 
         mockMvc.perform(
-            MockMvcRequestBuilders.post("/users/login")
+            post("/users/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJsonString(userLogin))
         )
@@ -130,7 +133,7 @@ internal class UserLoginControllerTest @Autowired constructor(
         session.setAttribute("email", userLogin.email)
 
         mockMvc.perform(
-            MockMvcRequestBuilders.post("/users/logout")
+            post("/users/logout")
                 .contentType(MediaType.APPLICATION_JSON)
                 .session(session)
         )
@@ -142,15 +145,12 @@ internal class UserLoginControllerTest @Autowired constructor(
     }
 
     fun getDocumentRequest() =
-        Preprocessors.preprocessRequest(
-            Preprocessors.modifyUris().scheme("http").host("localhost").port(8080),
-            Preprocessors.prettyPrint()
-        )
+        preprocessRequest(modifyUris().scheme("http").host("localhost").port(8080), prettyPrint())
 
-    fun getDocumentResponse() = Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+    fun getDocumentResponse() = preprocessResponse(prettyPrint())
 
     @Throws(JsonProcessingException::class)
-    private fun toJsonString(userLogin: UserLogin): String {
-        return objectMapper.writeValueAsString(userLogin)
+    private fun toJsonString(dto: Any): String {
+        return objectMapper.writeValueAsString(dto)
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses (이 PR이 다루는 문제) -->
Fixes #57

<!--- Detailed description of the change/feature (변경 / 기능에 대한 자세한 설명) -->
### 상세 내용
- Redis CacheManager를 설정하여 전체 사용자 피드 조회 캐싱 적용

**캐싱 적용 이유**
- 한번 읽어온 조회 결과를 캐시 메모리에 저장해둔다면 매번 DB로부터 호출하지 않고 데이터를 가져올 수 있기 때문에 조회시 더 빠른 속도를 보장할 수 있습니다.

**글로벌 캐싱 적용**
- 로컬 캐싱은 서버 간의 데이터가 공유가 되지 않아 각 캐시간의 서로 다른 상태를 가질 수 있기 때문에 일관성 문제가 발생할 수 있습니다. 따라서, 글로벌 캐싱을 사용하였습니다. 
- 글로벌 캐싱을 적용하여 별도로 캐시 서버를 두어 서버에서 캐시 서버를 참조하게 하였습니다. 캐시 데이터를 얻으려 할 때 마다 네트워크 트래픽이 발생하기 때문에 로컬 캐싱보다 속도는 느리지만, 확장된 서버간 데이터를 쉽게 공유할 수 있기 때문에 로컬 캐싱의 정합성 문제와 중복된 캐시 데이터로 인한 서버 자원 낭비 등 문제점을 해결할 수 있습니다.

**캐시 저장소와 세션 저장소 분리**
- Redis는 하나의 CPU로 동작하기 때문에 한 번에 하나의 커맨드만 실행할 수 있습니다. 평균적으로 초당 10만 개의 get/set이 가능하지만, 하나의 명령이 실행되고 있는 동안에 다음 명령은 무조건 대기해야하는 상황이 발생합니다. 
- 따라서, 레디스 서버를 목적과 기능별(Session, Cache)로 분리하고 분리된 서버의 수 만큼 CPU를 더 많이 사용할 수 있도록 하게 하여 처리 속도를 향상시켰습니다.

**기타**
- 오탈자 및 누락된 어노테이션등 추가하였습니다.



